### PR TITLE
Configure ai-memory-service build and healthcheck

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   ai-memory-service:
-    image: node:15-alpine
+    build: ../scripts
     container_name: ai-radar-memory
     restart: unless-stopped
     working_dir: /app
@@ -83,7 +83,12 @@ services:
         condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    command: ["sleep", "infinity"]  # Запустится позже
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- switch the ai-memory-service container to build from the local scripts Dockerfile instead of pulling node:15-alpine
- remove the placeholder sleep command so the service uses its npm start command and add a curl-based healthcheck for /health

## Testing
- `npm test`
- `docker compose -f infra/docker-compose.yml up --build`


------
https://chatgpt.com/codex/tasks/task_e_68de50aadb4c83248e2e12ab20341153