### PR TITLE
Настроить запуск memory-service в docker-compose

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     container_name: ai-radar-memory
     restart: unless-stopped
     working_dir: /app
+    command: ["sh", "-c", "npm ci --only=production && npm run start"]
     environment:
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432


### PR DESCRIPTION
## Summary
- добавить команду запуска для сервиса ai-memory-service в docker-compose, чтобы ставить зависимости при старте и запускать приложение

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de5237be448324b87e956a3ec81f32