### PR TITLE
Handle zero generation options in memory service

### DIFF
--- a/scripts/__tests__/chat-with-memory.test.js
+++ b/scripts/__tests__/chat-with-memory.test.js
@@ -1,0 +1,66 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const axios = require('axios');
+const pg = require('pg');
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('chat-with-memory передает нулевые temperature и top_p в Ollama', async () => {
+  const queryMock = mock.fn(async () => ({ rows: [] }));
+  mock.method(pg, 'Pool', function MockPool() {
+    return { query: queryMock };
+  });
+  const axiosPostMock = mock.method(axios, 'post', async () => ({
+    data: {
+      response: 'assistant response',
+      eval_count: 42,
+    },
+  }));
+
+  process.env.NODE_ENV = 'test';
+  const modulePath = require.resolve('../memory-service');
+  delete require.cache[modulePath];
+
+  try {
+    const { chatWithMemoryHandler } = require('../memory-service');
+
+    const req = {
+      body: {
+        message: 'Hello',
+        sessionId: 'session-1',
+        options: {
+          temperature: 0,
+          top_p: 0,
+        },
+      },
+    };
+    const res = createMockResponse();
+
+    await chatWithMemoryHandler(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.response, 'assistant response');
+    assert.equal(queryMock.mock.calls.length, 3);
+
+    const optionsArg = axiosPostMock.mock.calls[0].arguments[1].options;
+    assert.equal(optionsArg.temperature, 0);
+    assert.equal(optionsArg.top_p, 0);
+  } finally {
+    mock.restoreAll();
+    delete require.cache[modulePath];
+    delete process.env.NODE_ENV;
+  }
+});

--- a/scripts/memory-service.js
+++ b/scripts/memory-service.js
@@ -1,21 +1,20 @@
 const express = require('express');
 const { Pool } = require('pg');
 const axios = require('axios');
-const { v4: uuidv4 } = require('uuid');
 
 const app = express();
 app.use(express.json());
 
 // Подключение к PostgreSQL
 const pool = new Pool({
-  host: process.env.POSTGRES_HOST || 'postgres',
-  port: process.env.POSTGRES_PORT || 5432,
+  host: process.env.POSTGRES_HOST ?? 'postgres',
+  port: process.env.POSTGRES_PORT ?? 5432,
   database: process.env.POSTGRES_DB,
   user: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
 });
 
-const OLLAMA_URL = process.env.OLLAMA_BASE_URL || 'http://host.docker.internal:11434';
+const OLLAMA_URL = process.env.OLLAMA_BASE_URL ?? 'http://host.docker.internal:11434';
 
 // Функция для получения контекста из памяти
 async function getSessionContext(sessionId, limit = 10) {
@@ -44,10 +43,10 @@ async function saveMessage(sessionId, role, messageText, modelUsed = null, token
 }
 
 // API endpoint для обработки запроса с памятью
-app.post('/chat-with-memory', async (req, res) => {
+async function chatWithMemoryHandler(req, res) {
   try {
     const { message, sessionId = 'default', model = 'deepseek-r1:70b', options = {} } = req.body;
-    
+
     // Получаем контекст из памяти
     const context = await getSessionContext(sessionId);
     
@@ -64,10 +63,10 @@ app.post('/chat-with-memory', async (req, res) => {
       prompt: fullPrompt,
       stream: false,
       options: {
-        temperature: options.temperature || 0.3,
-        top_p: options.top_p || 0.9,
-        ...options
-      }
+        ...options,
+        temperature: options.temperature ?? 0.3,
+        top_p: options.top_p ?? 0.9,
+      },
     });
     
     const response = ollamaResponse.data.response;
@@ -87,14 +86,22 @@ app.post('/chat-with-memory', async (req, res) => {
     console.error('Error in chat-with-memory:', error);
     res.status(500).json({ error: error.message, stack: error.stack });
   }
-});
+}
+
+app.post('/chat-with-memory', chatWithMemoryHandler);
 
 // Healthcheck endpoint
 app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`AI Memory Service running on port ${PORT}`);
-});
+const PORT = process.env.PORT ?? 3000;
+let server;
+
+if (process.env.NODE_ENV !== 'test') {
+  server = app.listen(PORT, () => {
+    console.log(`AI Memory Service running on port ${PORT}`);
+  });
+}
+
+module.exports = { app, server, chatWithMemoryHandler };

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "start": "node memory-service.js",
-    "test": "node test-connection.js"
+    "test": "node --test __tests__",
+    "test:connection": "node test-connection.js"
   }
 }

--- a/scripts/test-connection.js
+++ b/scripts/test-connection.js
@@ -5,8 +5,34 @@ async function testOllamaConnection() {
     const response = await axios.get('http://host.docker.internal:11434/api/tags');
     console.log('✅ Ollama connection successful');
     console.log('Available models:', response.data.models?.map(m => m.name) || []);
+
+    const modelForSmokeTest = response.data.models?.[0]?.name;
+    if (modelForSmokeTest) {
+      await testZeroTemperatureAndTopP(modelForSmokeTest);
+    } else {
+      console.warn('⚠️ Нет доступных моделей для smoke-теста generate.');
+    }
   } catch (error) {
     console.error('❌ Ollama connection failed:', error.message);
+  }
+}
+
+async function testZeroTemperatureAndTopP(model) {
+  try {
+    const response = await axios.post('http://host.docker.internal:11434/api/generate', {
+      model,
+      prompt: 'Smoke test prompt',
+      stream: false,
+      options: {
+        temperature: 0,
+        top_p: 0,
+      },
+    });
+
+    console.log(`✅ Генерация с temperature=0 и top_p=0 для модели ${model} прошла успешно`);
+    console.log('Ответ (усечённый):', String(response.data.response).slice(0, 100));
+  } catch (error) {
+    console.error(`❌ Ошибка генерации с temperature=0 и top_p=0 для модели ${model}:`, error.message);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the memory service preserves zero values when building Ollama options and expose the handler for testing
- add a Node test that verifies `temperature = 0` and `top_p = 0` are forwarded to the Ollama request
- extend the smoke script to exercise a zero-parameter generation call and update npm scripts to run the new checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de5238dbb48324810e783b0ab575b5