### PR TITLE
Fix memory service test mocks initialization

### DIFF
--- a/scripts/memory-service.test.js
+++ b/scripts/memory-service.test.js
@@ -1,25 +1,29 @@
-const { app, getSessionContext, saveMessage, pool } = require('./memory-service');
-const request = require('supertest');
-const axios = require('axios');
+const mockPgPool = {
+  query: jest.fn(),
+  connect: jest.fn(),
+  end: jest.fn(),
+};
 
 // Mock the 'pg' module
-jest.mock('pg', () => {
-  const mPool = {
-    query: jest.fn(),
-    connect: jest.fn(),
-    end: jest.fn(),
-  };
-  return { Pool: jest.fn(() => mPool) };
-});
+jest.mock('pg', () => ({
+  Pool: jest.fn(() => mockPgPool),
+}));
 
 // Mock 'axios'
 jest.mock('axios');
+
+const request = require('supertest');
+const axios = require('axios');
+const { app, getSessionContext, saveMessage, pool } = require('./memory-service');
 
 describe('Memory Service', () => {
   let mockPool;
 
   beforeEach(() => {
     // Reset mocks before each test
+    mockPgPool.query.mockReset();
+    mockPgPool.connect.mockReset();
+    mockPgPool.end.mockReset();
     jest.clearAllMocks();
     mockPool = pool;
   });


### PR DESCRIPTION
## Summary
- move the Jest mocks for `pg` and `axios` ahead of the memory-service import so the module initializes with mocked dependencies
- reset the mocked pool methods before each test to ensure isolation across test cases

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68de7e01aaa083248b97efed62fb3262