### PR TITLE
Add CI workflow for Node scripts service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  scripts:
+    name: Scripts Service CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: scripts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: scripts/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs on pushes and pull requests to main and master
- install Node.js 20, install dependencies, and run lint and test scripts for the scripts service

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7f5659d48324a370ad2df5490830