### PR TITLE
Add ESLint configuration for scripts package

### DIFF
--- a/scripts/.eslintignore
+++ b/scripts/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "root": true,
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2021,
+    "sourceType": "script"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.js"],
+      "env": {
+        "jest": true
+      }
+    }
+  ],
+  "rules": {
+    "semi": ["error", "always"],
+    "quotes": ["error", "single"],
+    "no-console": "off"
+  }
+}

--- a/scripts/eslint.config.cjs
+++ b/scripts/eslint.config.cjs
@@ -1,0 +1,38 @@
+module.exports = [
+  {
+    ignores: ['scripts/node_modules/**', 'scripts/coverage/**']
+  },
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'commonjs',
+      globals: {
+        console: 'readonly',
+        module: 'readonly',
+        require: 'readonly',
+        process: 'readonly',
+        __dirname: 'readonly'
+      }
+    },
+    rules: {
+      semi: ['error', 'always'],
+      quotes: ['error', 'single'],
+      'no-console': 'off'
+    }
+  },
+  {
+    files: ['scripts/**/*.test.js'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        jest: 'readonly'
+      }
+    }
+  }
+];

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,9 +11,12 @@
   },
   "scripts": {
     "start": "node memory-service.js",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
+    "eslint": "^8.57.0",
     "jest": "^30.2.0",
     "supertest": "^7.1.4"
   }


### PR DESCRIPTION
## Summary
- add eslint to the scripts package devDependencies and expose lint scripts
- introduce eslint configuration files tailored for the memory service and its tests
- add ignore rules for build artefacts in the scripts workspace

## Testing
- npm run lint
- npm install *(fails with 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68de7f4bfda08324bcb15079a4dbf457