### PR TITLE
Refactor memory service app factory

### DIFF
--- a/scripts/memory-service.test.js
+++ b/scripts/memory-service.test.js
@@ -2,11 +2,8 @@ const request = require('supertest');
 
 const mockPgPool = {
   query: jest.fn(),
-  connect: jest.fn(),
-  end: jest.fn(),
 };
 
-// Mock the 'pg' module
 jest.mock('pg', () => ({
   Pool: jest.fn(() => mockPgPool),
 }));
@@ -18,15 +15,86 @@ jest.mock('./llm-client', () => ({
 }));
 
 const llmClient = require('./llm-client');
-const axios = require('axios');
-const { app, getSessionContext, saveMessage, pool } = require('./memory-service');
+const { createApp, chatWithMemoryHandler } = require('./memory-service');
 
-describe('Memory Service', () => {
-  let mockPool;
-
-  beforeEach(() => {
-    // Reset mocks before each test
-    mockPgPool.query.mockReset();
-    mockPgPool.connect.mockReset();
-    mockPgPool.end.mockReset();
+function createResponse() {
+  const res = {};
+  res.statusCode = 200;
+  res.status = jest.fn().mockImplementation(code => {
+    res.statusCode = code;
+    return res;
   });
+  res.json = jest.fn().mockImplementation(body => {
+    res.body = body;
+    return res;
+  });
+  return res;
+}
+
+describe('memory-service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('chatWithMemoryHandler использует переданные зависимости', async () => {
+    const pool = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ role: 'system', message_text: 'hi' }] })
+        .mockResolvedValue({ rows: [] }),
+    };
+
+    llmClient.generate.mockResolvedValue({ response: 'Ответ', evalCount: 5 });
+
+    const handler = chatWithMemoryHandler({ pool, llmClient });
+
+    const req = {
+      body: {
+        message: 'Привет',
+        sessionId: 'session-1',
+        model: 'test-model',
+        options: { temperature: 0.1 },
+      },
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(pool.query).toHaveBeenCalled();
+    expect(llmClient.generate).toHaveBeenCalledWith(expect.any(String), {
+      model: 'test-model',
+      options: { temperature: 0.1 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        response: 'Ответ',
+        sessionId: 'session-1',
+        model: 'test-model',
+      }),
+    );
+  });
+
+  it('createApp создаёт express приложение и регистрирует маршруты', async () => {
+    mockPgPool.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValue({ rows: [] });
+    llmClient.generate.mockResolvedValue({ response: 'hello', evalCount: 1 });
+
+    const app = createApp();
+
+    const healthResponse = await request(app).get('/health');
+    expect(healthResponse.status).toBe(200);
+    expect(healthResponse.body.status).toBe('ok');
+
+    const chatResponse = await request(app)
+      .post('/chat-with-memory')
+      .send({ message: 'ping', sessionId: 'abc' });
+
+    expect(chatResponse.status).toBe(200);
+    expect(chatResponse.body).toHaveProperty('response', 'hello');
+    expect(app.pool).toBeDefined();
+    expect(typeof app.getSessionContext).toBe('function');
+    expect(typeof app.saveMessage).toBe('function');
+  });
+});

--- a/scripts/tests/e2e/chat-with-memory.e2e.test.js
+++ b/scripts/tests/e2e/chat-with-memory.e2e.test.js
@@ -7,7 +7,7 @@ jest.setTimeout(30000);
 describe('E2E: /chat-with-memory', () => {
   let pool;
   let app;
-  let axiosStub;
+  let llmStub;
   let skipSuite = false;
 
   beforeAll(async () => {
@@ -34,16 +34,14 @@ describe('E2E: /chat-with-memory', () => {
         )
       `);
 
-      axiosStub = {
-        post: jest.fn().mockResolvedValue({
-          data: {
-            response: 'E2E response',
-            eval_count: 256,
-          },
+      llmStub = {
+        generate: jest.fn().mockResolvedValue({
+          response: 'E2E response',
+          evalCount: 256,
         }),
       };
 
-      app = createApp({ pool, axiosInstance: axiosStub, ollamaBaseUrl: 'http://ollama.e2e' });
+      app = createApp({ pool, llm: llmStub, defaultModel: 'deepseek-r1:70b' });
     } catch (error) {
       skipSuite = true;
       console.warn('E2E тесты пропущены из-за недоступности PostgreSQL:', error.message);

--- a/scripts/tests/smoke/chat-with-memory.smoke.test.js
+++ b/scripts/tests/smoke/chat-with-memory.smoke.test.js
@@ -11,16 +11,14 @@ describe('Smoke: /chat-with-memory', () => {
         .mockResolvedValueOnce({ rows: [] }),
     };
 
-    const axiosStub = {
-      post: jest.fn().mockResolvedValue({
-        data: {
-          response: 'smoke-response',
-          eval_count: 10,
-        },
+    const llmStub = {
+      generate: jest.fn().mockResolvedValue({
+        response: 'smoke-response',
+        evalCount: 10,
       }),
     };
 
-    const app = createApp({ pool: poolStub, axiosInstance: axiosStub, ollamaBaseUrl: 'http://ollama.smoke' });
+    const app = createApp({ pool: poolStub, llm: llmStub });
 
     const response = await request(app)
       .post('/chat-with-memory')

--- a/scripts/tests/smoke/health.smoke.test.js
+++ b/scripts/tests/smoke/health.smoke.test.js
@@ -4,8 +4,8 @@ const { createApp } = require('../../memory-service');
 describe('Smoke: /health', () => {
   it('возвращает статус ok и метку времени', async () => {
     const poolStub = { query: jest.fn() };
-    const axiosStub = { post: jest.fn() };
-    const app = createApp({ pool: poolStub, axiosInstance: axiosStub });
+    const llmStub = { generate: jest.fn() };
+    const app = createApp({ pool: poolStub, llm: llmStub });
 
     const response = await request(app).get('/health');
 

--- a/scripts/tests/unit/memory-service.unit.test.js
+++ b/scripts/tests/unit/memory-service.unit.test.js
@@ -3,20 +3,20 @@ const { createApp } = require('../../memory-service');
 
 describe('Memory service unit tests', () => {
   let poolMock;
-  let axiosMock;
+  let llmMock;
   let app;
 
   beforeEach(() => {
     poolMock = {
       query: jest.fn(),
     };
-    axiosMock = {
-      post: jest.fn(),
+    llmMock = {
+      generate: jest.fn(),
     };
     app = createApp({
       pool: poolMock,
-      axiosInstance: axiosMock,
-      ollamaBaseUrl: 'http://ollama.test',
+      llm: llmMock,
+      defaultModel: 'test-model',
     });
   });
 
@@ -34,11 +34,9 @@ describe('Memory service unit tests', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
 
-    axiosMock.post.mockResolvedValue({
-      data: {
-        response: 'Привет! Чем могу помочь?',
-        eval_count: 128,
-      },
+    llmMock.generate.mockResolvedValue({
+      response: 'Привет! Чем могу помочь?',
+      evalCount: 128,
     });
 
     const payload = {
@@ -58,13 +56,10 @@ describe('Memory service unit tests', () => {
     expect(response.body.model).toBe(payload.model);
     expect(response.body.contextUsed).toBe(false);
 
-    expect(axiosMock.post).toHaveBeenCalledWith('http://ollama.test/api/generate', {
+    expect(llmMock.generate).toHaveBeenCalledWith('user: Расскажи мне что-нибудь', {
       model: payload.model,
-      prompt: 'user: Расскажи мне что-нибудь',
-      stream: false,
       options: expect.objectContaining({
         temperature: 0.7,
-        top_p: 0.9,
       }),
     });
 


### PR DESCRIPTION
## Summary
- extract the /chat-with-memory handler into a reusable factory with dependency injection
- add a createApp factory that wires dependencies, attaches helpers, and maintains backward-compatible exports
- update tests to cover the new injection points and rely on the llm client abstraction

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de8620ff5083249f078a0ff62b55e3