### PR TITLE
Add unit coverage for memory service helpers

### DIFF
--- a/scripts/memory-service.test.js
+++ b/scripts/memory-service.test.js
@@ -1,4 +1,10 @@
-const request = require('supertest');
+jest.mock(
+  'dotenv',
+  () => ({
+    config: jest.fn(),
+  }),
+  { virtual: true }
+);
 
 const mockPgPool = {
   query: jest.fn(),
@@ -6,27 +12,92 @@ const mockPgPool = {
   end: jest.fn(),
 };
 
-// Mock the 'pg' module
 jest.mock('pg', () => ({
   Pool: jest.fn(() => mockPgPool),
 }));
 
-jest.mock('./llm-client', () => ({
+const mockLlmClient = {
   generate: jest.fn(),
   MOCK_COMPLETION: { response: 'Mocked LLM response', evalCount: 0 },
   DISABLED_COMPLETION: { response: 'LLM service is disabled', evalCount: 0 },
-}));
+};
 
-const llmClient = require('./llm-client');
-const axios = require('axios');
-const { app, getSessionContext, saveMessage, pool } = require('./memory-service');
+jest.mock('./llm-client', () => mockLlmClient);
 
-describe('Memory Service', () => {
-  let mockPool;
+describe('memory-service вспомогательные функции', () => {
+  let getSessionContext;
+  let saveMessage;
+  let createPool;
+  let servicePool;
 
   beforeEach(() => {
-    // Reset mocks before each test
-    mockPgPool.query.mockReset();
-    mockPgPool.connect.mockReset();
-    mockPgPool.end.mockReset();
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    ({ getSessionContext, saveMessage, createPool, pool: servicePool } = require('./memory-service'));
   });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('использует фабрику createPool так же, как остальные тесты', () => {
+    const anotherPool = createPool();
+
+    expect(anotherPool).toBe(mockPgPool);
+    expect(servicePool).toBe(mockPgPool);
+  });
+
+  it('возвращает сообщения из базы данных в хронологическом порядке', async () => {
+    const rowsFromDb = [
+      { role: 'assistant', message_text: 'Последний ответ', model_used: 'model-a', created_at: '2024-05-02T10:00:00Z' },
+      { role: 'user', message_text: 'Первый вопрос', model_used: 'model-a', created_at: '2024-05-02T09:59:00Z' },
+    ];
+    mockPgPool.query.mockResolvedValueOnce({ rows: [...rowsFromDb] });
+
+    const result = await getSessionContext('session-42', 2);
+
+    expect(mockPgPool.query).toHaveBeenCalledWith(
+      'SELECT role, message_text, model_used, created_at FROM ai_sessions WHERE session_id = $1 ORDER BY created_at DESC LIMIT $2',
+      ['session-42', 2]
+    );
+    expect(result).toEqual(rowsFromDb.slice().reverse());
+  });
+
+  it('возвращает пустой массив и логирует ошибку при сбое запроса', async () => {
+    const error = new Error('database unavailable');
+    mockPgPool.query.mockRejectedValueOnce(error);
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await getSessionContext('session-error', 5);
+
+    expect(result).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith('Error getting session context:', error);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('сохраняет сообщение в базе данных', async () => {
+    mockPgPool.query.mockResolvedValueOnce();
+
+    await saveMessage('session-100', 'assistant', 'Ответ с памятью', 'model-b', 64);
+
+    expect(mockPgPool.query).toHaveBeenCalledWith(
+      'INSERT INTO ai_sessions (session_id, role, message_text, model_used, tokens_used) VALUES ($1, $2, $3, $4, $5)',
+      ['session-100', 'assistant', 'Ответ с памятью', 'model-b', 64]
+    );
+  });
+
+  it('логирует ошибку при неудачной попытке сохранения сообщения', async () => {
+    const error = new Error('insert failed');
+    mockPgPool.query.mockRejectedValueOnce(error);
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await saveMessage('session-100', 'user', 'Ошибка', 'model-b', null);
+
+    expect(consoleSpy).toHaveBeenCalledWith('Error saving message:', error);
+
+    consoleSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- mock dotenv and llm client dependencies to safely load the memory service in unit tests
- add focused tests that cover getSessionContext and saveMessage behaviour with the shared pool factory
- verify error handling and SQL arguments when persisting or reading chat history

## Testing
- `cd scripts && npx jest memory-service.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68de8622e4c88324a88e9c186a038f8f