### PR TITLE
Mock llm client in memory service tests

### DIFF
--- a/scripts/tests/smoke/chat-with-memory.smoke.test.js
+++ b/scripts/tests/smoke/chat-with-memory.smoke.test.js
@@ -11,20 +11,23 @@ describe('Smoke: /chat-with-memory', () => {
         .mockResolvedValueOnce({ rows: [] }),
     };
 
-    const axiosStub = {
-      post: jest.fn().mockResolvedValue({
-        data: {
-          response: 'smoke-response',
-          eval_count: 10,
-        },
+    const llmClientStub = {
+      generate: jest.fn().mockResolvedValue({
+        response: 'smoke-response',
+        evalCount: 10,
+        disabled: false,
       }),
     };
 
-    const app = createApp({ pool: poolStub, axiosInstance: axiosStub, ollamaBaseUrl: 'http://ollama.smoke' });
+    const app = createApp({ pool: poolStub, llmClient: llmClientStub });
 
     const response = await request(app)
       .post('/chat-with-memory')
-      .send({ message: 'ping', sessionId: 'smoke-session' });
+      .send({
+        message: 'ping',
+        sessionId: 'smoke-session',
+        options: { temperature: 0, top_p: 0 },
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual(
@@ -32,7 +35,14 @@ describe('Smoke: /chat-with-memory', () => {
         response: 'smoke-response',
         sessionId: 'smoke-session',
         model: 'deepseek-r1:70b',
+        evalCount: 10,
+        llmDisabled: false,
       }),
     );
+
+    expect(llmClientStub.generate).toHaveBeenCalledWith('user: ping', {
+      model: 'deepseek-r1:70b',
+      options: expect.objectContaining({ temperature: 0, top_p: 0 }),
+    });
   });
 });

--- a/scripts/tests/smoke/health.smoke.test.js
+++ b/scripts/tests/smoke/health.smoke.test.js
@@ -4,8 +4,8 @@ const { createApp } = require('../../memory-service');
 describe('Smoke: /health', () => {
   it('возвращает статус ok и метку времени', async () => {
     const poolStub = { query: jest.fn() };
-    const axiosStub = { post: jest.fn() };
-    const app = createApp({ pool: poolStub, axiosInstance: axiosStub });
+    const llmClientStub = { generate: jest.fn() };
+    const app = createApp({ pool: poolStub, llmClient: llmClientStub });
 
     const response = await request(app).get('/health');
 

--- a/scripts/tests/unit/memory-service.unit.test.js
+++ b/scripts/tests/unit/memory-service.unit.test.js
@@ -3,20 +3,19 @@ const { createApp } = require('../../memory-service');
 
 describe('Memory service unit tests', () => {
   let poolMock;
-  let axiosMock;
+  let llmClientMock;
   let app;
 
   beforeEach(() => {
     poolMock = {
       query: jest.fn(),
     };
-    axiosMock = {
-      post: jest.fn(),
+    llmClientMock = {
+      generate: jest.fn(),
     };
     app = createApp({
       pool: poolMock,
-      axiosInstance: axiosMock,
-      ollamaBaseUrl: 'http://ollama.test',
+      llmClient: llmClientMock,
     });
   });
 
@@ -34,11 +33,10 @@ describe('Memory service unit tests', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
 
-    axiosMock.post.mockResolvedValue({
-      data: {
-        response: 'Привет! Чем могу помочь?',
-        eval_count: 128,
-      },
+    llmClientMock.generate.mockResolvedValue({
+      response: 'Привет! Чем могу помочь?',
+      evalCount: 128,
+      disabled: false,
     });
 
     const payload = {
@@ -57,14 +55,13 @@ describe('Memory service unit tests', () => {
     expect(response.body.sessionId).toBe(payload.sessionId);
     expect(response.body.model).toBe(payload.model);
     expect(response.body.contextUsed).toBe(false);
+    expect(response.body.evalCount).toBe(128);
+    expect(response.body.llmDisabled).toBe(false);
 
-    expect(axiosMock.post).toHaveBeenCalledWith('http://ollama.test/api/generate', {
+    expect(llmClientMock.generate).toHaveBeenCalledWith('user: Расскажи мне что-нибудь', {
       model: payload.model,
-      prompt: 'user: Расскажи мне что-нибудь',
-      stream: false,
       options: expect.objectContaining({
         temperature: 0.7,
-        top_p: 0.9,
       }),
     });
 


### PR DESCRIPTION
## Summary
- refactor the memory service factory to allow injecting a custom LLM client for testing
- update unit, smoke, and e2e chat-with-memory tests to mock llmClient.generate and assert returned metadata
- adjust health smoke test to rely on the injectable LLM client stub

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de862176a48324b399ff7e49098679