### PR TITLE
Add entrypoint for memory service and refresh smoke tests

### DIFF
--- a/scripts/memory-service.js
+++ b/scripts/memory-service.js
@@ -86,3 +86,12 @@ function createService({ pool: providedPool, llmClient: providedLlmClient } = {}
 }
 
 module.exports = { createService, createPool };
+
+if (require.main === module) {
+  const { app } = createService();
+  const port = process.env.PORT || 3000;
+
+  app.listen(port, () => {
+    console.log(`Memory service listening on port ${port}`);
+  });
+}

--- a/scripts/tests/smoke/health.smoke.test.js
+++ b/scripts/tests/smoke/health.smoke.test.js
@@ -1,20 +1,25 @@
 const request = require('supertest');
-const { createApp } = require('../../memory-service');
+const { createService } = require('../../memory-service');
 
 describe('Smoke: /health', () => {
   it('возвращает статус ok и метку времени', async () => {
     const poolStub = { query: jest.fn() };
     const llmClient = { generate: jest.fn() };
-    const app = createApp({ pool: poolStub, llmClient });
+    const { app } = createService({ pool: poolStub, llmClient });
+    const server = app.listen(0);
 
-    const response = await request(app).get('/health');
+    try {
+      const response = await request(server).get('/health');
 
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        status: 'ok',
-        timestamp: expect.any(String),
-      }),
-    );
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          timestamp: expect.any(String),
+        }),
+      );
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
   });
 });


### PR DESCRIPTION
## Summary
- start the memory service automatically when the module is executed directly
- update smoke tests to create real HTTP servers via the service factory for /health and /chat

## Testing
- npm run test:smoke *(fails: npm registry returned 403 during dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68df882a12e88324b808d3bf0e07959e