### PR TITLE
Align memory service with ai_sessions workflow

### DIFF
--- a/scripts/__tests__/chat-with-memory.test.js
+++ b/scripts/__tests__/chat-with-memory.test.js
@@ -1,63 +1,49 @@
 const { test, mock } = require('node:test');
 const assert = require('node:assert/strict');
-const pg = require('pg');
+const request = require('supertest');
 
-function createMockResponse() {
-  return {
-    statusCode: 200,
-    body: undefined,
-    status(code) {
-      this.statusCode = code;
-      return this;
-    },
-    json(payload) {
-      this.body = payload;
-      return this;
-    },
-  };
-}
+const pg = require('pg');
 
 test('chat-with-memory передает нулевые temperature и top_p в Ollama', async () => {
   const queryMock = mock.fn(async () => ({ rows: [] }));
   mock.method(pg, 'Pool', function MockPool() {
-    return { query: queryMock };
+    return { query: queryMock, end: mock.fn() };
   });
   process.env.NODE_ENV = 'test';
   const modulePath = require.resolve('../memory-service');
   delete require.cache[modulePath];
 
   try {
-    const { chatWithMemoryHandler } = require('../memory-service');
+    const { createService } = require('../memory-service');
 
     const llmMock = {
       generate: mock.fn(async () => ({
         response: 'assistant response',
         evalCount: 42,
+        model: 'test-model',
       })),
     };
 
-    const req = {
-      body: {
+    const { app } = createService({
+      pool: { query: queryMock },
+      llmClient: llmMock,
+      defaultModel: 'test-model',
+    });
+
+    const res = await request(app)
+      .post('/chat')
+      .send({
         message: 'Hello',
         sessionId: 'session-1',
         options: {
           temperature: 0,
           top_p: 0,
         },
-      },
-    };
-    const res = createMockResponse();
+      });
 
-    const handler = chatWithMemoryHandler({
-      pool: { query: queryMock },
-      llmClient: llmMock,
-    });
-
-    await handler(req, res);
-
-    assert.equal(res.statusCode, 200);
+    assert.equal(res.status, 200);
     assert.equal(res.body.response, 'assistant response');
-    assert.equal(queryMock.mock.calls.length, 3);
+    assert.equal(queryMock.mock.callCount(), 3);
 
     const optionsArg = llmMock.generate.mock.calls[0].arguments[1].options;
     assert.equal(optionsArg.temperature, 0);

--- a/scripts/memory-service.js
+++ b/scripts/memory-service.js
@@ -35,30 +35,56 @@ const express = require('express');
 const { Pool } = require('pg');
 const llmClient = require('./llm-client');
 
-function createPool() {
-  return new Pool({ connectionString: process.env.DATABASE_URL });
+function createPool(options = {}) {
+  const { connectionString = process.env.DATABASE_URL, ...rest } = options;
+  const poolConfig = { ...rest };
+  if (connectionString) {
+    poolConfig.connectionString = connectionString;
+  }
+  return new Pool(poolConfig);
 }
 
-function createService({ pool: providedPool, llmClient: providedLlmClient } = {}) {
+function formatMessagesForPrompt(messages, latestUserMessage) {
+  const fullContext = latestUserMessage ? [...messages, latestUserMessage] : messages;
+  return fullContext.map(({ role, message_text: text }) => `${role}: ${text}`).join('\n');
+}
+
+function createService({ pool: providedPool, llmClient: providedLlmClient, defaultModel } = {}) {
   const app = express();
   app.use(express.json());
 
   const pool = providedPool ?? createPool();
   const activeLlmClient = providedLlmClient ?? llmClient;
+  const fallbackModel = defaultModel || process.env.LLM_DEFAULT_MODEL || 'deepseek-r1:70b';
 
   async function getSessionContext(sessionId, limit = 10) {
-    const result = await pool.query(
-      'SELECT role, content FROM messages WHERE session_id = $1 ORDER BY timestamp DESC LIMIT $2',
-      [sessionId, limit]
-    );
-    return result.rows.reverse();
+    try {
+      const result = await pool.query(
+        `SELECT role, message_text, model_used, tokens_used, created_at
+         FROM ai_sessions
+         WHERE session_id = $1
+         ORDER BY created_at DESC
+         LIMIT $2`,
+        [sessionId, limit]
+      );
+      return result.rows.reverse();
+    } catch (error) {
+      console.error('Error getting session context:', error);
+      return [];
+    }
   }
 
-  async function saveMessage(sessionId, role, content) {
-    await pool.query(
-      'INSERT INTO messages (session_id, role, content, timestamp) VALUES ($1, $2, $3, NOW())',
-      [sessionId, role, content]
-    );
+  async function saveMessage(sessionId, role, messageText, modelUsed = null, tokensUsed = null) {
+    try {
+      await pool.query(
+        `INSERT INTO ai_sessions (session_id, role, message_text, model_used, tokens_used)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [sessionId, role, messageText, modelUsed, tokensUsed]
+      );
+    } catch (error) {
+      console.error('Error saving message:', error);
+      throw error;
+    }
   }
 
   app.get('/health', (req, res) => {
@@ -66,23 +92,45 @@ function createService({ pool: providedPool, llmClient: providedLlmClient } = {}
   });
 
   app.post('/chat', async (req, res) => {
-    const { sessionId, message } = req.body;
+    const { sessionId, message, model = fallbackModel, options = {} } = req.body || {};
     if (!sessionId || !message) {
       return res.status(400).json({ error: 'sessionId and message are required' });
     }
     try {
-      await saveMessage(sessionId, 'user', message);
-      const context = await getSessionContext(sessionId);
-      const { content } = await activeLlmClient.generate({ prompt: message, context });
-      await saveMessage(sessionId, 'assistant', content);
-      res.status(200).json({ response: content });
+      const previousContext = await getSessionContext(sessionId);
+      const userMessage = { role: 'user', message_text: message };
+      await saveMessage(sessionId, 'user', message, model, null);
+
+      const prompt = formatMessagesForPrompt(previousContext, userMessage);
+      const llmResult = await activeLlmClient.generate(prompt, { model, options });
+      const assistantResponse = llmResult?.response;
+      if (!assistantResponse) {
+        throw new Error('LLM returned empty response');
+      }
+
+      const resolvedModel = llmResult?.model ?? model ?? fallbackModel;
+      const tokensUsed = llmResult?.evalCount ?? null;
+
+      await saveMessage(sessionId, 'assistant', assistantResponse, resolvedModel, tokensUsed);
+
+      res.status(200).json({
+        response: assistantResponse,
+        sessionId,
+        model: resolvedModel,
+        contextUsed: previousContext.length > 0,
+        evalCount: llmResult?.evalCount ?? null,
+        llmDisabled: Boolean(llmResult?.disabled ?? false),
+      });
     } catch (error) {
       console.error('Error in /chat:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   });
 
-  return { app, pool };
+  app.getSessionContext = getSessionContext;
+  app.saveMessage = saveMessage;
+
+  return { app, pool, getSessionContext, saveMessage };
 }
 
 module.exports = { createService, createPool };

--- a/scripts/tests/smoke/health.smoke.test.js
+++ b/scripts/tests/smoke/health.smoke.test.js
@@ -1,11 +1,11 @@
 const request = require('supertest');
-const { createApp } = require('../../memory-service');
+const { createService } = require('../../memory-service');
 
 describe('Smoke: /health', () => {
   it('возвращает статус ok и метку времени', async () => {
     const poolStub = { query: jest.fn() };
     const llmClient = { generate: jest.fn() };
-    const app = createApp({ pool: poolStub, llmClient });
+    const { app } = createService({ pool: poolStub, llmClient });
 
     const response = await request(app).get('/health');
 
@@ -14,7 +14,7 @@ describe('Smoke: /health', () => {
       expect.objectContaining({
         status: 'ok',
         timestamp: expect.any(String),
-      }),
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- update the memory service to use the ai_sessions table, enrich /chat responses, and expose helper accessors
- migrate unit, smoke, e2e, and node:test suites to rely on createService and the real /chat route with ai_sessions fixtures
- allow createPool overrides for PostgreSQL connectivity and clean up only the test sessions during e2e teardown

## Testing
- npm test *(fails: jest: not found because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df882bf75083248715e49aaa843ba8